### PR TITLE
Upgrade for Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -6,11 +6,13 @@
     "source-directories": [
         "src"
     ],
-    "exposed-modules": ["RFC5988"],
+    "exposed-modules": [
+        "RFC5988"
+    ],
     "dependencies": {
-        "Bogdanp/elm-combine": "2.2.1 <= v < 3.0.0",
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "Bogdanp/elm-combine": "3.1.1 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/RFC5988.elm
+++ b/src/RFC5988.elm
@@ -86,7 +86,7 @@ rfc5988 =
             |> map (\uri -> { emptyLink | target = uri })
         )
             <* string ";"
-            `andThen` updateTargetAttributes
+            |> andThen updateTargetAttributes
 
 
 linkParam : Parser ( String, String )
@@ -94,7 +94,7 @@ linkParam =
     whitespace
         *> regex "[a-zA-Z]*"
         <* string "="
-        `andThen`
+        |> andThen
             (\key ->
                 string "\""
                     *> regex "[a-zA-Z]*"

--- a/src/RFC5988.elm
+++ b/src/RFC5988.elm
@@ -12,8 +12,7 @@ module RFC5988 exposing (rfc5988, rfc5988s, Link, emptyLink)
 -}
 
 import Dict exposing (Dict)
-import Combine exposing (parse, Parser, string, map, succeed, between, regex, sepBy, andThen)
-import Combine.Infix exposing ((<*), (*>))
+import Combine exposing ((<*), (*>), parse, Parser, string, map, succeed, between, regex, sepBy, andThen)
 
 
 {-| Produce an empty link.
@@ -43,7 +42,7 @@ type alias Link =
 
 {-| Parser for a list of links
 -}
-rfc5988s : Parser (List Link)
+rfc5988s : Parser state (List Link)
 rfc5988s =
     sepBy (whitespace *> string "," <* whitespace) rfc5988
 
@@ -56,7 +55,7 @@ rfc5988s =
       )
 
 -}
-rfc5988 : Parser Link
+rfc5988 : Parser state Link
 rfc5988 =
     let
         mergeParameter : ( String, String ) -> Link -> Link
@@ -77,7 +76,7 @@ rfc5988 =
         mergeTargetAttribute ( key, value ) acc =
             Dict.insert key value acc
 
-        updateTargetAttributes : Link -> Parser Link
+        updateTargetAttributes : Link -> Parser state Link
         updateTargetAttributes link =
             sepBy (string ";") linkParam
                 |> map (\keyVals -> mergeParameters keyVals link)
@@ -89,7 +88,7 @@ rfc5988 =
             |> andThen updateTargetAttributes
 
 
-linkParam : Parser ( String, String )
+linkParam : Parser state ( String, String )
 linkParam =
     whitespace
         *> regex "[a-zA-Z]*"
@@ -103,11 +102,11 @@ linkParam =
             )
 
 
-whitespace : Parser String
+whitespace : Parser state String
 whitespace =
     regex "[ \t\x0D\n]*"
 
 
-carets : Parser res -> Parser res
+carets : Parser state res -> Parser state res
 carets =
     between (string "<") (string ">")

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -5,7 +5,7 @@ import Test.Runner.Node exposing (run)
 import Json.Encode exposing (Value)
 
 
-main : Program Never
+main : Test.Runner.Node.TestProgram
 main =
     run emit Tests.all
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -3,9 +3,19 @@ module Tests exposing (..)
 import Test exposing (..)
 import Expect
 import String
-import Combine exposing (parse)
+import Combine exposing (Parser, ParseErr)
 import Dict exposing (Dict)
 import RFC5988 exposing (rfc5988, rfc5988s, Link, emptyLink)
+
+
+parse : Parser () res -> String -> Result (ParseErr ()) res
+parse parser input =
+    case Combine.parse parser input of
+        Ok ( _, _, result ) ->
+            Ok result
+
+        Err err ->
+            Err err
 
 
 all : Test
@@ -13,13 +23,13 @@ all =
     describe "Parsing RFC5988 Link Headers"
         [ test "Parsing a basic link header value" <|
             \() ->
-                Expect.equal (parse rfc5988 "<http://urbit.org>; rel=\"start\"") ( Ok basicLink, { input = "", position = 31 } )
+                Expect.equal (parse rfc5988 "<http://urbit.org>; rel=\"start\"") (Ok basicLink)
         , test "Parsing a link with some additional target attributes" <|
             \() ->
-                Expect.equal (parse rfc5988 "<http://urbit.org>; rel=\"start\"; borg=\"unimatrixzero\"") ( Ok { basicLink | targetAttributes = Dict.insert "borg" "unimatrixzero" basicLink.targetAttributes }, { input = "", position = 53 } )
+                Expect.equal (parse rfc5988 "<http://urbit.org>; rel=\"start\"; borg=\"unimatrixzero\"") (Ok { basicLink | targetAttributes = Dict.insert "borg" "unimatrixzero" basicLink.targetAttributes })
         , test "Parsing a list of links" <|
             \() ->
-                Expect.equal (parse rfc5988s listOfLinksString) ( Ok listOfLinks, { input = "", position = 152 } )
+                Expect.equal (parse rfc5988s listOfLinksString) (Ok listOfLinks)
         ]
 
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "Bogdanp/elm-combine": "2.2.1 <= v < 3.0.0",
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
+        "Bogdanp/elm-combine": "3.1.1 <= v < 4.0.0",
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Thank-you for this package! I'd like to use it for working with the GitHub API. This upgrades the library and tests for the current versions of Elm, elm-combine and node-test-runner.

The changes are:
 1. Apply an automated upgrade to the package files using elm-upgrade
 2. Update use of elm-combine following the migration guide in their README
 3. Adapt the type signature for the `main` function in the tests

